### PR TITLE
Update plugin.xml with correct version number

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
   xmlns:android="http://schemas.android.com/apk/res/android"
   id="cordova-plugin-calllog"
-  version="1.0.0">
+  version="1.2.1">
   <name>CALLLOG</name>
   <description>A plugin to get the device's call log</description>
   <license>MIT</license>


### PR DESCRIPTION
When I use:
`cordova plugins ls`
it lists:
```sh
...
cordova-plugin-calllog 1.0.0 "CALLLOG"
...
```
This is of course the incorrect version number, and doesn't match Cordova config.xml